### PR TITLE
Add Wilarus pipeline with PDF OCR parsing

### DIFF
--- a/MCP_wilarus/client.py
+++ b/MCP_wilarus/client.py
@@ -1,0 +1,15 @@
+import asyncio
+from orchestrator_agent import SearchAgent
+
+PROMPT = ""
+
+async def main():
+    async with SearchAgent(MCP_server_url="http://localhost:4200/sse") as bot:
+        answer = await bot.ask(prompt=PROMPT, system="""
+Вы — ассистент бухгалтера 1С. Используйте инструменты для работы с документами.
+В конце ответа добавьте тег </Finished>
+""")
+        print(answer)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/MCP_wilarus/llm_server.py
+++ b/MCP_wilarus/llm_server.py
@@ -1,0 +1,125 @@
+# llm_server.py
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import os
+import json
+import httpx
+from openai import OpenAI  # pip install openai-python-sdk
+
+# === Настройки ===
+# URL, по которому у нас «отвечает» vLLM (совместимый с OpenAI-API)
+LLM_BASE_URL = os.getenv("LLM_SERVER_URL", "http://0.0.0.0:8000/v1")
+
+# URL, по которому развернут ваш MCP server (тот, что уже создан на 9000)
+MCP_SERVER_URL = os.getenv("MCP_SERVER_URL", "http://localhost:9000")
+
+# === Инициализация FastAPI и клиента OpenAI/vLLM ===
+app = FastAPI(title="LLM Server")
+
+# Клиент, который будет стучаться в vLLM (OpenAI-совместимый)
+llm_client = OpenAI(
+    base_url=LLM_BASE_URL,
+    api_key="empty"  # vLLM обычно не проверяет API-ключ, поэтому «empty»
+)
+
+# === Pydantic‐модели ===
+class ChatRequest(BaseModel):
+    prompt: str
+    # Список описаний функций (инструментов), которые LLM может вызвать
+    tools: list
+
+
+@app.get("/get_tools")
+async def get_tools():
+    """
+    Возвращает MCP server’у список всех доступных инструментов.
+    MCP client при старте звонит сюда, чтобы получить tools и передать их в vLLM.
+    """
+    async with httpx.AsyncClient() as client:
+        try:
+            # Запрашиваем у «вашего» MCP server’а (порт 9000) список
+            # функций, доступных для вызова (ваша реализация в вопросе).
+            resp = await client.get(f"{MCP_SERVER_URL}/get_tools")
+            resp.raise_for_status()
+            data = resp.json()
+            return data  # ожидается формат {"tools": [ … ]}
+        except httpx.HTTPError as e:
+            raise HTTPException(status_code=500, detail=f"Ошибка при get_tools: {e}")
+
+
+@app.post("/chat")
+async def chat_endpoint(request: ChatRequest):
+    """
+    Основной эндпоинт: принимает { prompt, tools }, делает первый запрос в vLLM,
+    смотрит, есть ли function_call. Если он есть — дозванивается до MCP server
+    за результатом функции, затем отправляет второй запрос в vLLM, чтобы получить финальный
+    ответ. Возвращает MCP client’у JSON {"response": "..."}.
+    """
+    prompt_text = request.prompt
+    tools = request.tools  # это список dict’ов с описаниями функций (schema json‐schema)
+
+    # 1) Составляем «начальные» сообщения для vLLM
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant that can use tools."},
+        {"role": "user", "content": prompt_text}
+    ]
+    while True:
+        try:
+            # 2) Первый запрос в vLLM (с инструментами, tool_choice="auto").
+            completion = llm_client.chat.completions.create(
+                model="",
+                messages=messages,
+                tools=tools,
+                tool_choice="auto",
+                extra_body={"min_tokens": 5},
+                stream=False
+            )
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Ошибка при обращении к vLLM: {e}")
+
+        # 3) Проверяем, не захотел ли LLM вызвать функцию
+        first_choice = completion.choices[0]
+        finish_reason = first_choice.finish_reason
+        print(first_choice)
+        # Если vLLM не вернул function_call, значит — просто обычный текст
+        if finish_reason != "tool_calls":
+            text = first_choice.message.content
+            return {"response": text}
+
+        # === Если пришёл function_call ===
+        tool_calls = getattr(first_choice.message, "tool_calls", None)
+        call = tool_calls[0]
+        tool_name = call.function.name
+        # Аргументы функции — это JSON строка, разбираем её
+        func_args = json.loads(call.function.arguments or "{}")
+
+        # 4) Вызываем MCP server, чтобы получить результат функции
+        #    POST http://localhost:9000/get_data {"tool":tool_name, "parameters":func_args}
+        async with httpx.AsyncClient() as client:
+            try:
+                tool_req = {"tool": tool_name, "parameters": func_args}
+                resp = await client.post(f"{MCP_SERVER_URL}/get_data", json=tool_req)
+                resp.raise_for_status()
+                tool_result = resp.json()["result"]
+            except httpx.HTTPStatusError as he:
+                code = he.response.status_code
+                detail = he.response.json().get("detail", he.response.text)
+                raise HTTPException(status_code=code, detail=f"Ошибка MCP server при {tool_name}: {detail}")
+            except Exception as e:
+                raise HTTPException(status_code=500, detail=f"Ошибка при get_data: {e}")
+
+        # 5) Делаем «второй» запрос в vLLM, чтобы сконкатенировать function_call + результат функции
+        #    и получить финальный текст.
+        messages.append({
+            "role": "assistant",
+            "content": f'{{"name": "{tool_name}", "arguments": "{func_args}"}}'
+        })
+        messages.append({
+            "role": "function",
+            "name": tool_name,
+            "content": json.dumps(tool_result)
+        })
+        messages.append({
+            "role": "user",
+            "content": "Дай финальный ответ в виде цифры подразделения или вызови следующий инструмент в виде JSON"
+        })

--- a/MCP_wilarus/mcp_client.py
+++ b/MCP_wilarus/mcp_client.py
@@ -1,0 +1,44 @@
+# mcp_client.py
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import requests
+import os
+
+# === Настройки ===
+LLM_SERVER_URL = os.getenv("LLM_SERVER_URL", "http://localhost:8022")
+
+app = FastAPI(title="MCP Client")
+
+
+class PromptRequest(BaseModel):
+    prompt: str
+
+
+@app.post("/process")
+async def process_prompt(request: PromptRequest):
+    """
+    Принимает JSON { "prompt": "..." },
+    отдаёт в LLM server (сначала get_tools, затем chat) и возвращает конечный ответ.
+    """
+    prompt_text = request.prompt
+
+    try:
+        resp_tools = requests.get(f"{LLM_SERVER_URL}/get_tools", timeout=None)
+        resp_tools.raise_for_status()
+        tools_data = resp_tools.json()
+        tools_list = tools_data.get("tools", [])
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Не удалось получить tools у LLM server: {e}")
+
+    payload = {
+        "prompt": prompt_text,
+        "tools": tools_list
+    }
+    try:
+        resp_chat = requests.post(f"{LLM_SERVER_URL}/chat", json=payload)
+        resp_chat.raise_for_status()
+        chat_data = resp_chat.json()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Ошибка при /chat у LLM server: {e}")
+
+    return {"response": chat_data["response"]}

--- a/MCP_wilarus/mcp_server.py
+++ b/MCP_wilarus/mcp_server.py
@@ -1,0 +1,135 @@
+import httpx
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from typing import Annotated, List, Dict, Optional
+from pydantic import Field
+from mcp.server.fastmcp import FastMCP
+
+API_BASE_URL = "http://localhost:9000/1c"
+
+mcp = FastMCP("mcp_wilarus")
+
+# --- Tools interacting with dummy 1C API ---
+
+@mcp.tool()
+async def get_nomenclature(name: Annotated[str, Field(description="Наименование товара")]) -> Optional[Dict]:
+    """Проверить наличие номенклатуры в 1С по имени."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{API_BASE_URL}/nomenclature", params={"name": name})
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.json()
+
+@mcp.tool()
+async def create_nomenclature(name: Annotated[str, Field(description="Наименование")], unit: Annotated[str, Field(description="Единица измерения")]) -> Dict:
+    """Создать новую номенклатуру в 1С."""
+    payload = {"name": name, "unit": unit}
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{API_BASE_URL}/nomenclature", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+@mcp.tool()
+async def get_contractor(inn: Annotated[str, Field(description="ИНН контрагента")]) -> Optional[Dict]:
+    """Найти контрагента по ИНН."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{API_BASE_URL}/contractors", params={"inn": inn})
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.json()
+
+@mcp.tool()
+async def create_contractor(name: str, inn: str, account: str, bank: str) -> Dict:
+    """Создать карточку контрагента."""
+    payload = {"name": name, "inn": inn, "account": account, "bank": bank}
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{API_BASE_URL}/contractors", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+@mcp.tool()
+async def create_payment(data: Dict) -> Dict:
+    """Создать платёжное поручение."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{API_BASE_URL}/payments", json=data)
+        resp.raise_for_status()
+        return resp.json()
+
+@mcp.tool()
+async def create_receipt(data: Dict) -> Dict:
+    """Создать документ поступления товаров."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{API_BASE_URL}/receipts", json=data)
+        resp.raise_for_status()
+        return resp.json()
+
+@mcp.tool()
+async def get_receipt_status(receipt_id: str) -> Dict:
+    """Получить статус документа поступления."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{API_BASE_URL}/receipts/{receipt_id}")
+        resp.raise_for_status()
+        return resp.json()
+
+# --- Dummy 1C API implementation ---
+
+nomenclature_db: Dict[str, Dict] = {}
+contractor_db: Dict[str, Dict] = {}
+payment_db: Dict[str, Dict] = {}
+receipt_db: Dict[str, Dict] = {}
+
+@mcp.custom_route("/1c/nomenclature", methods=["GET"])
+async def api_get_nomenclature(request: Request):
+    name = request.query_params.get("name")
+    for nid, item in nomenclature_db.items():
+        if item["name"].lower() == name.lower():
+            return JSONResponse({"id": nid, **item})
+    return JSONResponse({"detail": "not found"}, status_code=404)
+
+@mcp.custom_route("/1c/nomenclature", methods=["POST"])
+async def api_create_nomenclature(request: Request):
+    data = await request.json()
+    nid = str(len(nomenclature_db) + 1)
+    nomenclature_db[nid] = data
+    return JSONResponse({"id": nid, **data})
+
+@mcp.custom_route("/1c/contractors", methods=["GET"])
+async def api_get_contractor(request: Request):
+    inn = request.query_params.get("inn")
+    for cid, c in contractor_db.items():
+        if c["inn"] == inn:
+            return JSONResponse({"id": cid, **c})
+    return JSONResponse({"detail": "not found"}, status_code=404)
+
+@mcp.custom_route("/1c/contractors", methods=["POST"])
+async def api_create_contractor(request: Request):
+    data = await request.json()
+    cid = str(len(contractor_db) + 1)
+    contractor_db[cid] = data
+    return JSONResponse({"id": cid, **data})
+
+@mcp.custom_route("/1c/payments", methods=["POST"])
+async def api_create_payment(request: Request):
+    data = await request.json()
+    pid = str(len(payment_db) + 1)
+    payment_db[pid] = {"status": "created", **data}
+    return JSONResponse({"payment_id": pid, "status": "created"})
+
+@mcp.custom_route("/1c/receipts", methods=["POST"])
+async def api_create_receipt(request: Request):
+    data = await request.json()
+    rid = str(len(receipt_db) + 1)
+    receipt_db[rid] = {"status": "created", **data}
+    return JSONResponse({"receipt_id": rid, "status": "created"})
+
+@mcp.custom_route("/1c/receipts/{rid}", methods=["GET"])
+async def api_get_receipt(request: Request, rid: str):
+    rec = receipt_db.get(rid)
+    if not rec:
+        return JSONResponse({"detail": "not found"}, status_code=404)
+    return JSONResponse({"receipt_id": rid, "status": rec["status"]})
+
+if __name__ == "__main__":
+    mcp.run(transport="sse")

--- a/MCP_wilarus/orchestrator_agent.py
+++ b/MCP_wilarus/orchestrator_agent.py
@@ -1,0 +1,97 @@
+"""
+SearchAgent объединяет vLLM-чат и MCP-поиск.
+Использование:
+    async with SearchAgent("web_search/server.py") as bot:
+        answer = await bot.ask("Привет, мир!")
+"""
+import json, asyncio
+from openai import AsyncOpenAI
+from fastmcp import Client as MCP
+from fastmcp.client.transports import SSETransport
+
+def _mcp_to_openai(tools):
+    print(tools)
+    return [{
+        "type": "function",
+        "function": {
+            "name": t.name,
+            "description": t.description or "",
+            "parameters": t.inputSchema,
+        }
+    } for t in tools]
+
+
+class SearchAgent:
+    def __init__(
+            self,
+            MCP_server_url: str,
+            llm_url: str = "http://localhost:8000/v1",
+            model: str = "Salesforce/xLAM-2-32b-fc-r"
+    ):
+        self.transport = SSETransport(url=MCP_server_url)
+        self.mcp = MCP(self.transport)
+        self.llm = AsyncOpenAI(base_url=llm_url, api_key="dummy")
+        self.model = model
+        self.tools = None  # кеш описания инструментов
+
+    async def __aenter__(self):
+        await self.mcp.__aenter__()
+        await self.llm.__aenter__()
+        self.tools = _mcp_to_openai(await self.mcp.list_tools())
+        return self
+
+    async def __aexit__(self, *exc):
+        await self.mcp.__aexit__(*exc)
+        await self.llm.__aexit__(*exc)
+
+    async def ask(self, prompt: str, system: str | None = None) -> str:
+        """Отправляет один запрос LLM, автоматически обслуживая tool-calls."""
+        msgs = []
+        if system:
+            msgs.append({"role": "system", "content": system})
+        msgs.append({"role": "user", "content": prompt})
+
+        while True:
+            resp = ''
+            try:
+                resp = await self.llm.chat.completions.create(
+                    model=self.model,
+                    messages=msgs,
+                    tools=self.tools,
+                    tool_choice="auto",
+                    extra_body={
+                        "min_tokens": 5
+                    }
+                )
+            except Exception as e:
+                id = msgs[-1]['tool_call_id']
+                content = msgs[-1]['content']
+                msgs.append({
+                    "role": "tool",
+                    "tool_call_id": id,
+                    "content": content[:len(content) // 2]
+                })
+                msgs.pop(-2)
+
+            if not resp:
+                continue
+            msg = resp.choices[0].message
+
+            if msg.tool_calls:
+                for call in msg.tool_calls:
+                    args = json.loads(call.function.arguments)
+                    result = await self.mcp.call_tool(call.function.name, args)
+                    msgs.append({
+                        "role": "tool",
+                        "tool_call_id": call.id,
+                        "content": json.dumps(result[0].text)
+                    })
+                    print("function_called", result)
+                continue
+            if '</Finished>' not in msg.content:
+                msgs.append(
+                    {"role": "user", "content": "Дай конечный результат с тегом </Finished>, если ты закончил поиск. "
+                                                "Если тебе не хватает информации, получи информацию с другого сайта, скачай больше данных, "
+                                                "вызвав другой инструмент при помощи JSON запроса"})
+                continue
+            return msg.content

--- a/MCP_wilarus/parse_pdf.py
+++ b/MCP_wilarus/parse_pdf.py
@@ -1,0 +1,33 @@
+"""Utilities for extracting text from PDF documents."""
+from pdfminer.high_level import extract_text
+from pdf2image import convert_from_path
+import pytesseract
+from tempfile import TemporaryDirectory
+
+
+def extract_text_with_ocr(pdf_path: str) -> str:
+    """Fallback OCR extraction using Tesseract."""
+    text = ""
+    with TemporaryDirectory() as tmpdir:
+        images = convert_from_path(pdf_path, output_folder=tmpdir)
+        for img in images:
+            text += pytesseract.image_to_string(img, lang="rus+eng")
+    return text
+
+
+def parse_pdf(pdf_path: str) -> str:
+    """Return extracted text from a PDF. Uses text layer if available and
+    falls back to OCR when the text layer is empty."""
+    text = extract_text(pdf_path)
+    if (not text or len(text.strip()) < 50 or
+            "docs.yandex.ru" in text or "1/1" in text):
+        text = extract_text_with_ocr(pdf_path)
+    return text
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) < 2:
+        print("Usage: parse_pdf.py <file.pdf>")
+    else:
+        result = parse_pdf(sys.argv[1])
+        print(result)

--- a/MCP_wilarus/start_MCP.sh
+++ b/MCP_wilarus/start_MCP.sh
@@ -1,0 +1,21 @@
+echo "=== 1) Запуск MCP-сервера (mcp_server.py) на порту 9000 ==="
+nohup uvicorn mcp_server:mcp --host 0.0.0.0 --port 9000 > mcp_server.log 2>&1 &
+MCP_PID=$!
+echo "MCP-сервер запущен, PID=$MCP_PID"
+
+sleep 2
+
+echo "=== 2) Запуск LLM-сервера (llm_server.py) на порту 8022 ==="
+nohup uvicorn llm_server:app --host 0.0.0.0 --port 8022 > llm_server.log 2>&1 &
+LLM_PID=$!
+echo "LLM-сервер запущен, PID=$LLM_PID"
+
+sleep 2
+
+echo "=== 3) Запуск MCP-клиента (mcp_client.py) на порту 8021 ==="
+nohup uvicorn mcp_client:app --host 0.0.0.0 --port 8021 > mcp_client.log 2>&1 &
+CLIENT_PID=$!
+echo "MCP-клиент запущен, PID=$CLIENT_PID"
+
+echo "Чтобы остановить: kill $MCP_PID $LLM_PID $CLIENT_PID"
+

--- a/MCP_wilarus/vLLM/start_vllm.sh
+++ b/MCP_wilarus/vLLM/start_vllm.sh
@@ -1,0 +1,5 @@
+MODEL="Salesforce/xLAM-2-32b-fc-r"
+nohup vllm serve "$MODEL" \
+  --enable-auto-tool-choice \
+  --tool-call-parser xlam \
+  --tensor-parallel-size 2 &

--- a/MCP_wilarus/vLLM/xlam_tool_call_parser.py
+++ b/MCP_wilarus/vLLM/xlam_tool_call_parser.py
@@ -1,0 +1,155 @@
+import json
+import re
+from typing import Dict, List, Sequence, Union
+import partial_json_parser
+from partial_json_parser.core.options import Allow
+
+from vllm.entrypoints.openai.protocol import (
+    ChatCompletionRequest, DeltaMessage, DeltaToolCall,
+    DeltaFunctionCall, ExtractedToolCallInformation, ToolCall, FunctionCall
+)
+from vllm.entrypoints.openai.tool_parsers.abstract_tool_parser import ToolParser, ToolParserManager
+from vllm.utils import random_uuid
+from vllm.logger import init_logger
+from transformers import PreTrainedTokenizerBase
+from vllm.entrypoints.openai.tool_parsers.utils import (find_common_prefix,
+                                                        is_complete_json,
+                                                        partial_json_loads)
+
+logger = init_logger(__name__)
+
+@ToolParserManager.register_module("xlam")
+class xLAMToolParser(ToolParser):
+    def __init__(self, tokenizer: PreTrainedTokenizerBase):
+        super().__init__(tokenizer)
+        # State for streaming mode
+        self.prev_tool_calls: List[Dict] = []
+        self.current_tools_sent: List[bool] = []
+        self.streamed_args: List[str] = []
+        # Remove regex since we're parsing direct JSON
+
+    @staticmethod
+    def extract_first_json(s: str) -> str | None:
+        pos = 0
+
+        while True:
+            start = s.find('{', pos)
+            if start < 0:
+                return None
+
+            depth = 0
+            for i, ch in enumerate(s[start:], start):
+                if ch == '{':
+                    depth += 1
+                elif ch == '}':
+                    depth -= 1
+                    if depth == 0:
+                        candidate = s[start:i + 1]
+                        try:
+                            obj = json.loads(candidate)
+                            if isinstance(obj, dict) and not obj:
+                                pos = start + 1
+                                break
+                            return candidate
+                        except json.JSONDecodeError:
+                            pos = start + 1
+                            break
+            else:
+                return None
+
+
+    def extract_tool_calls(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest
+    ) -> ExtractedToolCallInformation:
+        try:
+            # Modified: Direct JSON parsing without looking for ```
+            json_str = self.extract_first_json(model_output)
+            print('model_output', model_output)
+            if not json_str:
+                return ExtractedToolCallInformation(
+                    tools_called=False,
+                    tool_calls=[],
+                    content=model_output
+                )
+            print('json_str', json_str)
+            json_str = '['+json_str+']'
+            tool_calls_data = json.loads(json_str)
+            tool_calls: List[ToolCall] = []
+            for idx, call in enumerate(tool_calls_data):
+                tool_call = ToolCall(
+                    id=f"call_{idx}_{random_uuid()}",
+                    type="function",
+                    function=FunctionCall(
+                        name=call["name"],
+                        arguments=json.dumps(call["arguments"])
+                    )
+                )
+                tool_calls.append(tool_call)
+
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=model_output
+            )
+
+        except Exception:
+            logger.exception("Error extracting tool calls")
+            return ExtractedToolCallInformation(
+                tools_called=False,
+                tool_calls=[],
+                content=model_output
+            )
+
+
+    def extract_tool_calls_streaming(
+            self,
+            previous_text: str,
+            current_text: str,
+            delta_text: str,
+            previous_token_ids: Sequence[int],
+            current_token_ids: Sequence[int],
+            delta_token_ids: Sequence[int],
+            request: ChatCompletionRequest,
+    ) -> Union[DeltaMessage, ExtractedToolCallInformation, None]:
+        if current_text.endswith("]"):
+            try:
+                json_str = self.extract_first_json(current_text)
+                print('model_output', current_text)
+                if not json_str:
+                    return ExtractedToolCallInformation(
+                        tools_called=False,
+                        tool_calls=[],
+                        content=model_output
+                    )
+                print('json_str', json_str)
+                json_str = '[' + json_str + ']'
+                tool_calls_data = json.loads(json_str)
+                tool_calls: List[ToolCall] = []
+                for idx, call in enumerate(tool_calls_data):
+                    tool_call = ToolCall(
+                        id=f"call_{idx}_{random_uuid()}",
+                        type="function",
+                        function=FunctionCall(
+                            name=call["name"],
+                            arguments=json.dumps(call["arguments"])
+                        )
+                    )
+                    tool_calls.append(tool_call)
+
+                return ExtractedToolCallInformation(
+                    tools_called=True,
+                    tool_calls=tool_calls,
+                    content=model_output
+                )
+
+            except Exception:
+                logger.exception("Error extracting tool calls")
+                return ExtractedToolCallInformation(
+                    tools_called=False,
+                    tool_calls=[],
+                    content=model_output
+                )
+        else:
+            return DeltaMessage(delta_text)


### PR DESCRIPTION
## Summary
- create `MCP_wilarus` module with full pipeline similar to other MCP servers
- add dummy 1C API and tools in `mcp_server.py`
- provide orchestrator agent, llm server, client and start scripts
- implement `parse_pdf.py` with OCR fallback
- include vLLM startup script

## Testing
- `python MCP_wilarus/parse_pdf.py MCP_wilarus/Элитан_Трейд_ООО_2024_10_02_Счет_оферта_971686Z_pdf_Я.pdf | head`


------
https://chatgpt.com/codex/tasks/task_e_6882141e01c08328b67e6b25f9543852